### PR TITLE
Parser optimization

### DIFF
--- a/include/parser/expr.hpp
+++ b/include/parser/expr.hpp
@@ -1,32 +1,51 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <cstdint>
 
 enum op_type_   { unknwn_ = -1, ptr_plus_, var_plus_, ptr_minus_, var_minus_, assign_, not_equal_ };
-enum expr_type_ { int_lit_expr_, bin_op_expr_, ptr_expr_ };
+enum expr_type_ { int_lit_expr_, bin_op_expr_, ptr_expr_, var_expr_ };
 
 struct expression_ {
+    intptr_t return_expr;
     expr_type_ expression_type;
 };
 
 struct integer_literal_ : expression_ {
     int intlit {};
 
-    integer_literal_(const int u_intlit = 0)
+    integer_literal_(const int& u_intlit = 0)
         :
         intlit {u_intlit}
     {
+        return_expr = intlit;
         expression_type = int_lit_expr_;
     }
 };
 
 struct pointer_ : expression_ {
-    char** ptr;
+    char* ptr;
 
-    pointer_(char** u_ptr = nullptr)
+    pointer_(char* u_ptr = nullptr)
         :
         ptr {u_ptr}
     {
+        return_expr = reinterpret_cast <intptr_t> (ptr);
+        expression_type = ptr_expr_;
+    }
+};
+
+struct variable_ : expression_ {
+    std::string id;
+    int value;
+
+    variable_(const std::string& u_id = "", const int& u_value = 0)
+        :
+        id {u_id},
+        value {u_value}
+    {
+        return_expr = value;
         expression_type = ptr_expr_;
     }
 };

--- a/include/parser/expr.hpp
+++ b/include/parser/expr.hpp
@@ -21,11 +21,11 @@ struct integer_literal_ : expression_ {
 };
 
 struct pointer_ : expression_ {
-    char* ptr;
+    char** ptr;
 
-    pointer_()
+    pointer_(char** u_ptr = nullptr)
         :
-        ptr {nullptr}
+        ptr {u_ptr}
     {
         expression_type = ptr_expr_;
     }

--- a/include/parser/parser.hpp
+++ b/include/parser/parser.hpp
@@ -2,20 +2,22 @@
 
 #include <lexer/lexer.hpp>
 
-#include <list>
+#include <vector>
 
 #include "stmt.hpp"
 
 class parse_tree {
     private:
-        std::list <std::shared_ptr <statement_>> data_ {}; // shared_ptr to make casting easier
+        std::vector <std::shared_ptr <statement_>> data_ {}; // shared_ptr to make casting easier
     public:
         parse_tree() = default;
 
-        inline std::list <std::shared_ptr <statement_>>& data()           { return data_; };
-        inline std::shared_ptr <statement_> back() const                  { return data_.back(); }
-        inline std::list <std::shared_ptr <statement_>>::iterator begin() { return data_.begin(); }
-        inline std::list <std::shared_ptr <statement_>>::iterator end()   { return data_.end(); }
+        const std::vector <std::shared_ptr <statement_>>& data()        { return data_; };
+        std::shared_ptr <statement_> back() const                       { return data_.back(); }
+        std::vector <std::shared_ptr <statement_>>::iterator begin()    { return data_.begin(); }
+        std::vector <std::shared_ptr <statement_>>::iterator end()      { return data_.end(); }
+
+        friend parse_tree parse(const std::vector <token_> data);
 };
 
 parse_tree parse(const std::vector <token_> data);

--- a/include/parser/stmt.hpp
+++ b/include/parser/stmt.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "expr.hpp"
-
 #include <memory>
 #include <functional>
+
+#include "expr.hpp"
 
 enum stmt_type_ { expr_stmt_, ctrl_stmt_, input_stmt_, output_stmt_ };
 
@@ -26,7 +26,7 @@ struct expression_statement_ : statement_ {
 };
 
 struct control_statement_ : statement_ {
-    std::list <std::shared_ptr <statement_>> body;
+    std::vector <std::shared_ptr <statement_>> body;
     std::shared_ptr <expression_> condition;
 
     control_statement_(std::shared_ptr <expression_> u_condition, 

--- a/include/parser/stmt.hpp
+++ b/include/parser/stmt.hpp
@@ -8,25 +8,20 @@
 enum stmt_type_ { expr_stmt_, ctrl_stmt_, input_stmt_, output_stmt_ };
 
 struct statement_ {
-    std::shared_ptr <expression_> return_expression;
-
+    std::shared_ptr <expression_> return_expression; // @TODO
     stmt_type_ statement_type;
-
     bool terminated;
-    char id;
 };
 
 struct expression_statement_ : statement_ {
     std::shared_ptr <expression_> body = nullptr;
 
-    expression_statement_(std::shared_ptr <expression_> u_body, const char u_id = '\0')
+    expression_statement_(std::shared_ptr <expression_> u_body)
         :
         body {std::move(u_body)}
     {
         statement_type = expr_stmt_;
         terminated = true;
-        id = u_id; // this id char is used for debugging,
-                   // and has no usage in regular flow
     }
 };
 
@@ -35,12 +30,11 @@ struct control_statement_ : statement_ {
     std::shared_ptr <expression_> condition;
 
     control_statement_(std::shared_ptr <expression_> u_condition, 
-            std::shared_ptr <statement_> u_body, const char u_id = '[')
+            std::shared_ptr <statement_> u_body)
         :
         condition {std::move(u_condition)}
     {
         body.emplace_back(std::move(u_body));
-        id = u_id;
         statement_type = ctrl_stmt_;
         terminated = false;
     }
@@ -49,19 +43,17 @@ struct control_statement_ : statement_ {
 struct input_statement_: statement_ {
     std::function <int(void)> input  = &std::getchar;
 
-    input_statement_(const char u_id = ',')
+    input_statement_()
     {
         statement_type = output_stmt_;
-        id = u_id;
     }
 };
 
 struct output_statement_: statement_ {
     std::function <int(int)> output = &std::putchar;
 
-    output_statement_(const char u_id = '.')
+    output_statement_()
     {
         statement_type = output_stmt_;
-        id = u_id;
     }
 };

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,7 +1,10 @@
 #include <codegen/codegen.hpp>
 
+#include <string>
+
 namespace {
-    void append_code(std::shared_ptr <expression_> expr, std::string& target)
+    void
+    append_code(std::shared_ptr <expression_> expr, std::string& target)
     {
         if (!expr) return;
 
@@ -13,16 +16,20 @@ namespace {
                     if (temp->right) { append_code(temp->right, target); }
                     switch (temp->operation) {
                         case var_plus_:
-                            target += "++*ptr;";
+                            target += "*ptr = *ptr + " + 
+                                std::to_string(std::static_pointer_cast <integer_literal_> (temp->right)->intlit) + ";";
                             break;
                         case var_minus_:
-                            target += "--*ptr;";
+                            target += "*ptr = *ptr - " + 
+                                std::to_string(std::static_pointer_cast <integer_literal_> (temp->right)->intlit) + ";";
                             break;
                         case ptr_plus_:
-                            target += "++ptr;";
+                            target += "ptr = ptr + " + 
+                                std::to_string(std::static_pointer_cast <integer_literal_> (temp->right)->intlit) + ";";
                             break;
                         case ptr_minus_:
-                            target += "--ptr;";
+                            target += "ptr = ptr - " + 
+                                std::to_string(std::static_pointer_cast <integer_literal_> (temp->right)->intlit) + ";";
                             break;
                         default: break;
                     }
@@ -32,7 +39,8 @@ namespace {
         }
     }
 
-    void append_code(std::shared_ptr <statement_> source, std::string& target)
+    void
+    append_code(std::shared_ptr <statement_> source, std::string& target)
     {
         switch (source.get()->statement_type) {
             case expr_stmt_:

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,44 +1,58 @@
 #include <codegen/codegen.hpp>
 
 namespace {
-    std::string
-    bf_to_c(const char ch)
+    void append_code(std::shared_ptr <expression_> expr, std::string& target)
     {
-        switch (ch) {
-            case '>':
-                return "++ptr;";
-            case '<':
-                return "--ptr;";
-            case '+':
-                return "++*ptr;";
-            case '-':
-                return "--*ptr;";
-            case '.':
-                return "putchar(*ptr);";
-            case ',':
-                return "*ptr = getchar();";
-            case '[':
-                return "while(*ptr != 0){";
-            case ']':
-                return "}";
+        if (!expr) return;
+
+        switch (expr.get()->expression_type) {
+            case bin_op_expr_:
+                {
+                    auto temp = std::static_pointer_cast <binary_operation_> (expr);
+                    if (temp->left)  { append_code(temp->left, target);  }
+                    if (temp->right) { append_code(temp->right, target); }
+                    switch (temp->operation) {
+                        case var_plus_:
+                            target += "++*ptr;";
+                            break;
+                        case var_minus_:
+                            target += "--*ptr;";
+                            break;
+                        case ptr_plus_:
+                            target += "++ptr;";
+                            break;
+                        case ptr_minus_:
+                            target += "--ptr;";
+                            break;
+                        default: break;
+                    }
+                }
+                break;
             default: break;
         }
-
-        return "";
     }
 
-    void 
-    append_code(std::list <std::shared_ptr <statement_>> source, std::string& target)
+    void append_code(std::shared_ptr <statement_> source, std::string& target)
     {
-        for (auto& x: source) {
-            target += bf_to_c((*x).id);
-            if ((*x).statement_type != ctrl_stmt_) {
-                continue;
-            }
-            if (std::static_pointer_cast <control_statement_> (x)->body.size() > 0) {
-                append_code(std::static_pointer_cast <control_statement_> (x)->body, target);
+        switch (source.get()->statement_type) {
+            case expr_stmt_:
+                append_code(std::static_pointer_cast <expression_statement_> (source)->body, target);
+                break;
+            case ctrl_stmt_:
+                target += "while(*ptr != 0) {";
+                {
+                    auto temp = std::static_pointer_cast <control_statement_> (source);
+
+                    for (auto& x: temp->body) { append_code(x, target); }
+                }
                 target += "}";
-            }
+                break;
+            case input_stmt_:
+                target += "getchar(*ptr);";
+                break;
+            case output_stmt_:
+                target += "putchar(*ptr);";
+                break;
         }
     }
 } // namespace
@@ -49,7 +63,9 @@ codegen(parse_tree pt)
     std::string result {};
     result += "#include<stdio.h>\nchar array[1000]={0};char *ptr=array;int main(void){";
 
-    append_code(pt.data(), result);
+    for (auto& x: pt.data()) {
+        append_code(x, result);
+    }
 
     result += "}";
     return result;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -16,20 +16,20 @@ namespace {
                     if (temp->right) { append_code(temp->right, target); }
                     switch (temp->operation) {
                         case var_plus_:
-                            target += "*ptr = *ptr + " + 
-                                std::to_string(std::static_pointer_cast <integer_literal_> (temp->right)->intlit) + ";";
+                            target += "*ptr=*ptr+" + 
+                                std::to_string(temp->right->return_expr) + ";";
                             break;
                         case var_minus_:
-                            target += "*ptr = *ptr - " + 
-                                std::to_string(std::static_pointer_cast <integer_literal_> (temp->right)->intlit) + ";";
+                            target += "*ptr=*ptr-" + 
+                                std::to_string(temp->right->return_expr) + ";";
                             break;
                         case ptr_plus_:
-                            target += "ptr = ptr + " + 
-                                std::to_string(std::static_pointer_cast <integer_literal_> (temp->right)->intlit) + ";";
+                            target += "ptr=ptr+" + 
+                                std::to_string(temp->right->return_expr) + ";";
                             break;
                         case ptr_minus_:
-                            target += "ptr = ptr - " + 
-                                std::to_string(std::static_pointer_cast <integer_literal_> (temp->right)->intlit) + ";";
+                            target += "ptr=ptr-" + 
+                                std::to_string(temp->right->return_expr) + ";";
                             break;
                         default: break;
                     }
@@ -47,7 +47,7 @@ namespace {
                 append_code(std::static_pointer_cast <expression_statement_> (source)->body, target);
                 break;
             case ctrl_stmt_:
-                target += "while(*ptr != 0) {";
+                target += "while(*ptr != 0){";
                 {
                     auto temp = std::static_pointer_cast <control_statement_> (source);
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -17,16 +17,16 @@ namespace {
                     if (temp->right) { exec_expr(temp->right, ptr); }
                     switch (temp->operation) {
                         case var_plus_:
-                            ++(**ptr);
+                            **ptr = **ptr + std::static_pointer_cast <integer_literal_> (temp->right)->intlit;
                             break;
                         case var_minus_:
-                            --(**ptr);
+                            **ptr = **ptr - std::static_pointer_cast <integer_literal_> (temp->right)->intlit;
                             break;
                         case ptr_plus_:
-                            ++(*ptr);
+                            *ptr = *ptr + std::static_pointer_cast <integer_literal_> (temp->right)->intlit;
                             break;
                         case ptr_minus_:
-                            --(*ptr);
+                            *ptr = *ptr - std::static_pointer_cast <integer_literal_> (temp->right)->intlit;
                             break;
                         default: break;
                     }

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -42,9 +42,6 @@ namespace {
 
         switch (stmt.get()->statement_type) {
             case expr_stmt_:
-                // @TODO: '\0' shouldn't appear in the parse tree in the first place!!
-                //        something went wrong probably!!
-                if (stmt->id == '\0') break;
                 exec_expr(std::static_pointer_cast <expression_statement_> (stmt)->body, ptr);
                 break;
             case ctrl_stmt_:
@@ -52,9 +49,7 @@ namespace {
                     auto temp = std::static_pointer_cast <control_statement_> (stmt);
 
                     while ((**ptr) != 0) {
-                        for (auto& x: temp->body) {
-                            exec_stmt(x, ptr);
-                        }
+                        for (auto& x: temp->body) { exec_stmt(x, ptr); }
                     }
                 }
                 break;

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -17,16 +17,16 @@ namespace {
                     if (temp->right) { exec_expr(temp->right, ptr); }
                     switch (temp->operation) {
                         case var_plus_:
-                            **ptr = **ptr + std::static_pointer_cast <integer_literal_> (temp->right)->intlit;
+                            **ptr = **ptr + temp->right->return_expr;
                             break;
                         case var_minus_:
-                            **ptr = **ptr - std::static_pointer_cast <integer_literal_> (temp->right)->intlit;
+                            **ptr = **ptr - temp->right->return_expr;
                             break;
                         case ptr_plus_:
-                            *ptr = *ptr + std::static_pointer_cast <integer_literal_> (temp->right)->intlit;
+                            *ptr = *ptr + temp->right->return_expr;
                             break;
                         case ptr_minus_:
-                            *ptr = *ptr - std::static_pointer_cast <integer_literal_> (temp->right)->intlit;
+                            *ptr = *ptr - temp->right->return_expr;
                             break;
                         default: break;
                     }
@@ -62,7 +62,7 @@ namespace {
         }
     }
 
-    void run(std::list <std::shared_ptr <statement_>> data, char** ptr)
+    void run(std::vector <std::shared_ptr <statement_>> data, char** ptr)
     {
         for (auto& stmt: data) {
             exec_stmt(stmt, ptr);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3,28 +3,26 @@
 
 namespace {
     op_type_
-    char2type (const char ch)
+    char_to_op_type (const char ch)
     {
         switch (ch) {
-            case '+':
-                return var_plus_;
-            case '-':
-                return var_minus_;
-            case '>':
-                return ptr_plus_;
-            case '<':
-                return ptr_minus_;
+            case '+': return var_plus_;
+            case '-': return var_minus_;
+            case '>': return ptr_plus_;
+            case '<': return ptr_minus_;
         }
-
         return unknwn_;
     }
 
+    // concrete builder of a variable value/pointer expression
+    // (`*ptr = *ptr + 1` or `ptr = ptr + 1`)
     std::shared_ptr <expression_statement_>
-    create_expr_stmt(const char ch)
+    create_expr_stmt(op_type_ type, int value = 1)
     {
-        switch (char2type(ch)) {
+        switch (type) {
             case var_plus_:
             case var_minus_:
+                // create a variable value binary operation
                 return  
                     std::make_shared <expression_statement_> (
                         std::make_shared <binary_operation_> (
@@ -32,15 +30,12 @@ namespace {
                             assign_,
                             std::make_shared <binary_operation_> (
                                 std::make_shared <integer_literal_> (),
-                                char2type(ch),
-                                std::make_shared <integer_literal_> ()
-                            )
-                        ),
-                        ch
-                );
-                break;
+                                type,
+                                std::make_shared <integer_literal_> (value)
+                )));
             case ptr_plus_:
             case ptr_minus_:
+                // create a pointer binary operation
                 return  
                     std::make_shared <expression_statement_> (
                         std::make_shared <binary_operation_> (
@@ -48,42 +43,40 @@ namespace {
                             assign_,
                             std::make_shared <binary_operation_> (
                                 std::make_shared <pointer_> (),
-                                char2type(ch),
+                                type,
                                 std::make_shared <integer_literal_> ()
-                            )
-                        ),
-                        ch
-                );
-                break;
+                )));
             default: break;
         }
 
         return nullptr;
     }
 
+    // concrete builder of a while loop (`while (*ptr != 0)`)
     std::shared_ptr <control_statement_>
     create_ctrl_stmt()
     {
-        return  std::make_shared <control_statement_> (
-                    std::make_shared <binary_operation_> (
-                        std::make_shared <integer_literal_> (),
-                        not_equal_,
-                        std::make_shared <integer_literal_> ()
-                    ),
-                    std::make_shared <statement_> ()
+        return  
+            std::make_shared <control_statement_> (
+                std::make_shared <binary_operation_> (
+                    std::make_shared <integer_literal_> (),
+                    not_equal_,
+                    std::make_shared <integer_literal_> (0)
+                ),
+                std::make_shared <statement_> ()
         );
     }
 
     input_statement_*
-    create_in_stmt(const char ch = ',')
+    create_in_stmt()
     {
-        return new input_statement_ {ch};
+        return new input_statement_ {};
     }
 
     output_statement_*
-    create_out_stmt(const char ch = '.')
+    create_out_stmt()
     {
-        return new output_statement_ {ch};
+        return new output_statement_ {};
     }
     
     parser_::issue_
@@ -91,6 +84,7 @@ namespace {
              const std::vector <token_>::iterator& source_end,
              std::list <std::shared_ptr <statement_>>& target)
     {
+        using namespace parser_; // for error processing
         static int bracket_count = 0;
         static token_ last_opening_bracket {};
 
@@ -98,44 +92,38 @@ namespace {
             switch ((*source_begin).type) {
                 case bracket_open_:
                     target.emplace_back(create_ctrl_stmt());
-
                     ++bracket_count;
                     last_opening_bracket.line = (*source_begin).line;
                     last_opening_bracket.column = (*source_begin).column;
                     ++source_begin; // skip the bracket
-
+                    // after the opening bracket add statements to the body of the
+                    // control statement and exit once the closing bracket appears
                     add_stmt(source_begin, source_end, 
-                             std::static_pointer_cast <control_statement_> (target.back())->body );
+                            std::static_pointer_cast <control_statement_> (target.back())->body);
                     break;
                 case bracket_close_:
-                    if (!bracket_count) {
-                        parser_::process_issue(parser_::unopened_bracket_, (*source_begin));
-                    }
+                    if (!bracket_count) { process_issue(unopened_bracket_, (*source_begin)); }
                     target.back()->terminated = true;
-
                     --bracket_count;
-                    ++source_begin;
-
-                    return parser_::none_;
+                    ++source_begin; // skip the bracket
+                    return none_;
                 case data_op_:
                 case ptr_op_:
-                    target.emplace_back(create_expr_stmt((*source_begin).data));
+                    target.emplace_back(
+                        create_expr_stmt(char_to_op_type((*source_begin).data)) );
                     break;
                 case input_cmd_:
-                    target.emplace_back(create_in_stmt((*source_begin).data));
+                    target.emplace_back(create_in_stmt());
                     break;
                 case output_cmd_:
-                    target.emplace_back(create_out_stmt((*source_begin).data));
+                    target.emplace_back(create_out_stmt());
                     break;
                 default: break;
             }
         }
 
-        if (bracket_count) {
-            parser_::process_issue(parser_::unclosed_bracket_, last_opening_bracket);
-        }
-
-        return parser_::none_;
+        if (bracket_count) { process_issue(unclosed_bracket_, last_opening_bracket); }
+        return none_;
     }
 } // namespace
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -44,7 +44,7 @@ namespace {
                             std::make_shared <binary_operation_> (
                                 std::make_shared <pointer_> (),
                                 type,
-                                std::make_shared <integer_literal_> ()
+                                std::make_shared <integer_literal_> (value)
                 )));
             default: break;
         }

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -21,3 +21,5 @@ else
     printf "\n\e[1mfailed tests: \033[32m$FAIL\e[0m"
 fi
 
+printf "\n"
+

--- a/test/sh/codegen.sh
+++ b/test/sh/codegen.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-$PWD/brainwhack --codegen $PWD/brainfuck/hello_world.bf &> /dev/null
+$PWD/../brainwhack --codegen $PWD/brainfuck/hello_world.bf &> /dev/null
 
 if [[ "$?" -eq 0 ]]; then
     gcc $PWD/brainfuck/hello_world.c
@@ -15,7 +15,7 @@ if [[ "$?" -eq 0 ]]; then
     fi
     rm $PWD/a.out
 fi
-rm $PWD/brainfuck/hello_world.c
+rm -f $PWD/brainfuck/hello_world.c
 
 printf "\e[1m\033[31mTEST FAIL\e[0m: \t\t\tCode generation\n"
 exit 125

--- a/test/sh/fatal_unclosed_bracket.sh
+++ b/test/sh/fatal_unclosed_bracket.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-$PWD/brainwhack $PWD/brainfuck/fatal_unclosed_bracket.bf &> /dev/null
+$PWD/../brainwhack $PWD/brainfuck/fatal_unclosed_bracket.bf &> /dev/null
 
 if [[ "$?" -ne 0 ]]; then
     printf "\e[1m\033[32mTEST PASS\e[0m: \t\t\tUnclosed bracket\n"

--- a/test/sh/fatal_unopened_bracket.sh
+++ b/test/sh/fatal_unopened_bracket.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-$PWD/brainwhack $PWD/brainfuck/fatal_unclosed_bracket.bf &> /dev/null
+$PWD/../brainwhack $PWD/brainfuck/fatal_unclosed_bracket.bf &> /dev/null
 
 if [[ "$?" -ne 0 ]]; then
-    printf "\e[1m\033[32mTEST PASS\e[0m: \t\t\tUnclosed bracket\n"
+    printf "\e[1m\033[32mTEST PASS\e[0m: \t\t\tUnopened bracket\n"
     exit 0
 else
-    printf "\e[1m\033[31mTEST FAIL\e[0m: \t\t\tUnclosed bracket\n"
+    printf "\e[1m\033[31mTEST FAIL\e[0m: \t\t\tUnopened bracket\n"
     exit 125
 fi
 

--- a/test/sh/hello_world.sh
+++ b/test/sh/hello_world.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-COMMAND=$($PWD/brainwhack $PWD/brainfuck/hello_world.bf)
+COMMAND=$($PWD/../brainwhack $PWD/brainfuck/hello_world.bf)
 
 if [ "$COMMAND" == "Hello World!" ]; then
     printf "\e[1m\033[32mTEST PASS\e[0m: \t\t\tHello world\n"

--- a/test/sh/print_seven.sh
+++ b/test/sh/print_seven.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-COMMAND=$($PWD/brainwhack $PWD/brainfuck/print_seven.bf)
+COMMAND=$($PWD/../brainwhack $PWD/brainfuck/print_seven.bf)
 
 if [ "$COMMAND" == "7" ]; then
     printf "\e[1m\033[32mTEST PASS\e[0m: \t\t\tPrint seven\n"


### PR DESCRIPTION
repetitive commands are now squashed, e.g. `++++` now gives `*ptr = *ptr + 4;`, instead of `*ptr = *ptr + 1;` four times.